### PR TITLE
 Add js-yaml as top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "history": "^2.0.0",
     "front-matter": "^2.0.6",
     "highlight.js": "^9.2.0",
+    "history": "^2.0.0",
+    "js-yaml": "^3.5.5",
     "markdown-it": "^6.0.0",
     "markdown-it-abbr": "^1.0.3",
     "markdown-it-attrs": "^0.1.8",


### PR DESCRIPTION
was causing the webpack build to fail (cf similar problem fixed in gatsbyjs/gatsby#174)

Error message:

    ERROR in ./wrappers/yaml.js
    Module not found: Error: Cannot resolve module 'js-yaml' in /home/username/gatsby-default/wrappers
     @ ./wrappers/yaml.js 17:14-32

`gatsby develop` starts well after performing this change.