### PR TITLE
Add page titles to all pages

### DIFF
--- a/pages/coffee-react.cjsx
+++ b/pages/coffee-react.cjsx
@@ -1,4 +1,6 @@
 React = require 'react'
+DocumentTitle = require 'react-document-title'
+config = require 'config'
 
 module.exports = React.createClass
   getInitialState: ->
@@ -11,10 +13,12 @@ module.exports = React.createClass
     @setState count: @state.count - 1
 
   render: ->
-    <div>
-      <h1>Coffeescript React.js components</h1>
-      <h3>Counter example</h3>
-      <p>{@state.count}</p>
-      <button onClick={@handlePlusClick}>+</button>
-      <button onClick={@handleMinusClick}>-</button>
-    </div>
+    <DocumentTitle title={config.config.siteTitle + ' | Coffeescript React.js components'}>
+      <div>
+        <h1>Coffeescript React.js components</h1>
+        <h3>Counter example</h3>
+        <p>{@state.count}</p>
+        <button onClick={@handlePlusClick}>+</button>
+        <button onClick={@handleMinusClick}>-</button>
+      </div>
+    </DocumentTitle>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Link } from 'react-router'
 import { prefixLink } from 'gatsby-helpers'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 // Styles for highlighted code blocks.
 import 'css/zenburn.css'
@@ -8,49 +10,51 @@ import 'css/zenburn.css'
 export default class Sass extends React.Component {
   render () {
     return (
-      <div>
-        <h1>
-          Hi people
-        </h1>
-        <p>Welcome to your new Gatsby site</p>
-        <h2>Below are some pages showing different capabilities built-in to Gatsby</h2>
-        <h3>Supported file types</h3>
-        <ul>
-          <li>
-            <Link to={prefixLink('/markdown/')}>Markdown</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/react/')}>JSX (React components)</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/coffee-react/')}>CJSX (Coffeescript React components)</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/html/')}>HTML</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/json/')}>JSON</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/yaml/')}>YAML</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/toml/')}>TOML</Link>
-          </li>
-        </ul>
-        <h3>Supported CSS processors</h3>
-        <ul>
-          <li>
-            <Link to={prefixLink('/postcss/')}>PostCSS</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/sass/')}>Sass</Link>
-          </li>
-          <li>
-            <Link to={prefixLink('/less/')}>Less</Link>
-          </li>
-        </ul>
-      </div>
+      <DocumentTitle title={config.siteTitle}>
+        <div>
+          <h1>
+            Hi people
+          </h1>
+          <p>Welcome to your new Gatsby site</p>
+          <h2>Below are some pages showing different capabilities built-in to Gatsby</h2>
+          <h3>Supported file types</h3>
+          <ul>
+            <li>
+              <Link to={prefixLink('/markdown/')}>Markdown</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/react/')}>JSX (React components)</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/coffee-react/')}>CJSX (Coffeescript React components)</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/html/')}>HTML</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/json/')}>JSON</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/yaml/')}>YAML</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/toml/')}>TOML</Link>
+            </li>
+          </ul>
+          <h3>Supported CSS processors</h3>
+          <ul>
+            <li>
+              <Link to={prefixLink('/postcss/')}>PostCSS</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/sass/')}>Sass</Link>
+            </li>
+            <li>
+              <Link to={prefixLink('/less/')}>Less</Link>
+            </li>
+          </ul>
+        </div>
+      </DocumentTitle>
     )
   }
 }

--- a/pages/less.js
+++ b/pages/less.js
@@ -1,30 +1,34 @@
 import React from 'react'
 import './example.less'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 export default class Less extends React.Component {
   render () {
     return (
-      <div>
-        <h1
-          className="the-less-class"
-        >
-          Hi lessy friends
-        </h1>
-        <div className="less-nav-example">
-          <h2>Nav example</h2>
-          <ul>
-            <li>
-              <a href="#">Store</a>
-            </li>
-            <li>
-              <a href="#">Help</a>
-            </li>
-            <li>
-              <a href="#">Logout</a>
-            </li>
-          </ul>
+      <DocumentTitle title={`${config.siteTitle} | Hi lessy friends`}>
+        <div>
+          <h1
+            className="the-less-class"
+          >
+            Hi lessy friends
+          </h1>
+          <div className="less-nav-example">
+            <h2>Nav example</h2>
+            <ul>
+              <li>
+                <a href="#">Store</a>
+              </li>
+              <li>
+                <a href="#">Help</a>
+              </li>
+              <li>
+                <a href="#">Logout</a>
+              </li>
+            </ul>
+          </div>
         </div>
-      </div>
+      </DocumentTitle>
     )
   }
 }

--- a/pages/postcss.js
+++ b/pages/postcss.js
@@ -1,28 +1,32 @@
 import React from 'react'
 import './example.css'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 export default class PostCSS extends React.Component {
   render () {
     return (
-      <div>
-        <h1 className="the-postcss-class">
-          Hi PostCSSy friends
-        </h1>
-        <div className="postcss-nav-example">
-          <h2>Nav example</h2>
-          <ul>
-            <li>
-              <a href="#">Store</a>
-            </li>
-            <li>
-              <a href="#">Help</a>
-            </li>
-            <li>
-              <a href="#">Logout</a>
-            </li>
-          </ul>
+      <DocumentTitle title={`${config.siteTitle} | Hi PostCSSy friends`}>
+        <div>
+          <h1 className="the-postcss-class">
+            Hi PostCSSy friends
+          </h1>
+          <div className="postcss-nav-example">
+            <h2>Nav example</h2>
+            <ul>
+              <li>
+                <a href="#">Store</a>
+              </li>
+              <li>
+                <a href="#">Help</a>
+              </li>
+              <li>
+                <a href="#">Logout</a>
+              </li>
+            </ul>
+          </div>
         </div>
-      </div>
+      </DocumentTitle>
     )
   }
 }

--- a/pages/react.js
+++ b/pages/react.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 export default class ReactComponent extends React.Component {
   constructor () {
@@ -16,13 +18,15 @@ export default class ReactComponent extends React.Component {
 
   render () {
     return (
-      <div>
-        <h1>React.js components</h1>
-        <h3>Counter example</h3>
-        <p>{this.state.count}</p>
-        <button onClick={() => this.handlePlusClick()}>+</button>
-        <button onClick={() => this.handleMinusClick()}>-</button>
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | React.js components`}>
+        <div>
+          <h1>React.js components</h1>
+          <h3>Counter example</h3>
+          <p>{this.state.count}</p>
+          <button onClick={() => this.handlePlusClick()}>+</button>
+          <button onClick={() => this.handleMinusClick()}>-</button>
+        </div>
+      </DocumentTitle>
     )
   }
 }

--- a/pages/sass.js
+++ b/pages/sass.js
@@ -1,30 +1,34 @@
 import React from 'react'
 import './example.scss'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 export default class Sass extends React.Component {
   render () {
     return (
-      <div>
-        <h1
-          className="the-sass-class"
-        >
-          Hi sassy friends
-        </h1>
-        <div className="sass-nav-example">
-          <h2>Nav example</h2>
-          <ul>
-            <li>
-              <a href="#">Store</a>
-            </li>
-            <li>
-              <a href="#">Help</a>
-            </li>
-            <li>
-              <a href="#">Logout</a>
-            </li>
-          </ul>
+      <DocumentTitle title={`${config.siteTitle} | Hi sassy friends`}>
+        <div>
+          <h1
+            className="the-sass-class"
+          >
+            Hi sassy friends
+          </h1>
+          <div className="sass-nav-example">
+            <h2>Nav example</h2>
+            <ul>
+              <li>
+                <a href="#">Store</a>
+              </li>
+              <li>
+                <a href="#">Help</a>
+              </li>
+              <li>
+                <a href="#">Logout</a>
+              </li>
+            </ul>
+          </div>
         </div>
-      </div>
+      </DocumentTitle>
     )
   }
 }

--- a/wrappers/html.js
+++ b/wrappers/html.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 module.exports = React.createClass({
   propTypes () {
@@ -9,10 +11,12 @@ module.exports = React.createClass({
   render () {
     const post = this.props.route.page.data
     return (
-      <div className="markdown">
-        <h1 dangerouslySetInnerHTML={{ __html: post.title }} />
-        <div dangerouslySetInnerHTML={{ __html: post.body }} />
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | ${post.title}`}>
+        <div className="markdown">
+          <h1 dangerouslySetInnerHTML={{ __html: post.title }} />
+          <div dangerouslySetInnerHTML={{ __html: post.body }} />
+        </div>
+      </DocumentTitle>
     )
   },
 })

--- a/wrappers/json.js
+++ b/wrappers/json.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 module.exports = React.createClass({
   propTypes () {
@@ -9,11 +11,13 @@ module.exports = React.createClass({
   render () {
     const data = this.props.route.page.data
     return (
-      <div>
-        <h1>{data.title}</h1>
-        <p>Raw view of json file</p>
-        <pre dangerouslySetInnerHTML={{ __html: JSON.stringify(data, null, 4) }} />
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | ${data.title}`}>
+        <div>
+          <h1>{data.title}</h1>
+          <p>Raw view of json file</p>
+          <pre dangerouslySetInnerHTML={{ __html: JSON.stringify(data, null, 4) }} />
+        </div>
+      </DocumentTitle>
     )
   },
 })

--- a/wrappers/md.js
+++ b/wrappers/md.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import 'css/markdown-styles.css'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 module.exports = React.createClass({
   propTypes () {
@@ -10,10 +12,12 @@ module.exports = React.createClass({
   render () {
     const post = this.props.route.page.data
     return (
-      <div className="markdown">
-        <h1>{post.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.body }} />
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | ${post.title}`}>
+        <div className="markdown">
+          <h1>{post.title}</h1>
+          <div dangerouslySetInnerHTML={{ __html: post.body }} />
+        </div>
+      </DocumentTitle>
     )
   },
 })

--- a/wrappers/toml.js
+++ b/wrappers/toml.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import toml from 'toml-js'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 module.exports = React.createClass({
   propTypes () {
@@ -10,11 +12,13 @@ module.exports = React.createClass({
   render () {
     const data = this.props.route.page.data
     return (
-      <div>
-        <h1>{data.title}</h1>
-        <p>Raw view of toml file</p>
-        <pre dangerouslySetInnerHTML={{ __html: toml.dump(data) }} />
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | ${data.title}`}>
+        <div>
+          <h1>{data.title}</h1>
+          <p>Raw view of toml file</p>
+          <pre dangerouslySetInnerHTML={{ __html: toml.dump(data) }} />
+        </div>
+      </DocumentTitle>
     )
   },
 })

--- a/wrappers/yaml.js
+++ b/wrappers/yaml.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import yaml from 'js-yaml'
+import DocumentTitle from 'react-document-title'
+import { config } from 'config'
 
 module.exports = React.createClass({
   propTypes () {
@@ -10,11 +12,13 @@ module.exports = React.createClass({
   render () {
     const data = this.props.route.page.data
     return (
-      <div>
-        <h1>{data.title}</h1>
-        <p>Raw view of yaml file</p>
-        <pre dangerouslySetInnerHTML={{ __html: yaml.safeDump(data) }} />
-      </div>
+      <DocumentTitle title={`${config.siteTitle} | ${data.title}`}>
+        <div>
+          <h1>{data.title}</h1>
+          <p>Raw view of yaml file</p>
+          <pre dangerouslySetInnerHTML={{ __html: yaml.safeDump(data) }} />
+        </div>
+      </DocumentTitle>
     )
   },
 })


### PR DESCRIPTION
I just wanted to try out gatsbyjs looks awesome, thanks!

I noticed the titles in the starter set did not work. This should fix it. 

DocumentTitle is used but somehow not completely implemented. As in the other starters I set the titles to be set in the wrappers. In the pages that are not using wrappers, I set it up in the according JS file. Not sure if it is ideal.

I not much into react so please look over it :) 