### PR TITLE
Typo fixed in "pages/markdown.md"

### DIFF
--- a/pages/markdown.md
+++ b/pages/markdown.md
@@ -50,7 +50,7 @@ Term 2 with *inline markup*
 
     Third paragraph of definition 2.
 
-### Abbriviation
+### Abbreviation
 *[HTML]: Hyper Text Markup Language
 *[W3C]:  World Wide Web Consortium
 The HTML specification


### PR DESCRIPTION
```
Abbriviation
    |
Abbreviation
```

I checked first to see if maybe `Abbriviation` was the American spelling (Canada has a weird mix of British and American spellings for words) but I couldn't find any reference to that being correct. All of the definitions had it spelled `Abbreviation`.

This may be the smallest PR possible with only a single character changed!
