### PR TITLE
Nelitfy button added to the deploy section to README for starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Install this starter (assuming Gatsby is installed) by running from your CLI:
 ```
 gatsby new gatsby-example-site
 ```
+## Deploy
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-default)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "public"
+  
+[template.environment]
+  NODE_ENV = "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,4 @@
   
 [template.environment]
   NODE_ENV = "production"
+  YARN_VERSION = "0.18.0"


### PR DESCRIPTION
Hey Kyle, Netlify created a new [deploy to netlify button](https://www.netlify.com/blog/2016/11/29/introducing-the-deploy-to-netlify-button/), which allows the user to test out the Gatsby template without cloning and spinning up gatsby. This PR is just including a button in the README.

Can you take a look this? Any feedback on this would be greatly appreciated.