### PR TITLE
Add frontmatter html title to html wrapper component

### DIFF
--- a/wrappers/html.js
+++ b/wrappers/html.js
@@ -11,7 +11,12 @@ module.exports = React.createClass({
   render () {
     const page = this.props.route.page.data
     return (
-      <div dangerouslySetInnerHTML={{ __html: page.body }} />
+      <div>
+        <Helmet
+          title={`${config.siteTitle} | ${page.title}`} 
+        />
+        <div dangerouslySetInnerHTML={{ __html: page.body }} />
+      </div>
     )
   },
 })


### PR DESCRIPTION
When first using this starter (if the developer is unaware of the wrappers), it's confusing that all the other types of pages adjust their titles accordingly except the html page. This PR would add consistency.