### PR TITLE
Use ES6 classes instead of React.createClass and use the React PropTypes package instead of React.PropTypes

### DIFF
--- a/html.js
+++ b/html.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 
 import { prefixLink } from 'gatsby-helpers'
@@ -7,12 +8,11 @@ import typography from './utils/typography'
 
 const BUILD_TIME = new Date().getTime()
 
-module.exports = React.createClass({
-  propTypes() {
-    return {
-      body: React.PropTypes.string,
-    }
-  },
+export default class HTML extends React.Component {
+  static propTypes = {
+    body: PropTypes.string
+  }
+
   render() {
     const head = Helmet.rewind()
 
@@ -50,5 +50,5 @@ module.exports = React.createClass({
         </body>
       </html>
     )
-  },
-})
+  }
+}

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -1,16 +1,16 @@
-import React from "react"
-import { Link } from "react-router"
-import { prefixLink } from "gatsby-helpers"
-import Helmet from "react-helmet"
-import { config } from "config"
-import { rhythm } from "../utils/typography"
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router'
+import { prefixLink } from 'gatsby-helpers'
+import Helmet from 'react-helmet'
+import { config } from 'config'
+import { rhythm } from '../utils/typography'
 
-module.exports = React.createClass({
-  propTypes() {
-    return {
-      children: React.PropTypes.any,
-    }
-  },
+export default class Template extends React.Component {
+  static propTypes = {
+    children: PropTypes.any
+  }
+
   render() {
     return (
       <div>
@@ -59,5 +59,5 @@ module.exports = React.createClass({
         </div>
       </div>
     )
-  },
-})
+  }
+}

--- a/wrappers/md.js
+++ b/wrappers/md.js
@@ -1,14 +1,14 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import 'css/markdown-styles.css'
 import Helmet from 'react-helmet'
 import { config } from 'config'
 
-module.exports = React.createClass({
-  propTypes() {
-    return {
-      router: React.PropTypes.object,
-    }
-  },
+export default class Markdown extends React.Component {
+  static propTypes = {
+    router: PropTypes.object,
+  }
+
   render() {
     const post = this.props.route.page.data
     return (
@@ -18,5 +18,5 @@ module.exports = React.createClass({
         <div dangerouslySetInnerHTML={{ __html: post.body }} />
       </div>
     )
-  },
-})
+  }
+}


### PR DESCRIPTION
Pretty straight forward, just switches the following:

```js
// old
import React from 'react'

module.exports = React.createClass({
  propTypes() {
    return {
      router: React.PropTypes.object,
    }
  },
});

// new
import React from 'react'
import PropTypes from 'prop-types'

export default class HTML extends React.Component {
  static propTypes = {
      router: React.PropTypes.object,
  }
}
```

