### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 .sass-cache/
 public/
 .cache/
+.DS_Store


### PR DESCRIPTION
Good idea to include `.DS_Store` in `.gitignore` so Mac users won't accidentally commit a bunch of garbage files into their repo and then wonder what the heck they are later.