### PR TITLE
Fix the format script to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js'",
+    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"src/**/*.js\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed the `'` to `\"` in the format script to be compatible with Windows.
Currently, you get this error:
![error](https://user-images.githubusercontent.com/8641243/32259552-89c25b50-be7e-11e7-9d9c-aec7f9af916f.png)
