### PR TITLE
Fix NPM WARN message about repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
   },
   "devDependencies": {
     "prettier": "^1.10.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://gatsbyjs/gatsby-starter-default.git"
   }
 }


### PR DESCRIPTION
When you run `npm install` on this repo right now, you usually get CLI feedback from NPM that says:
```
npm WARN gatsby-starter-default@1.0.0 No repository field.
```

Just defining the repository in the `package.json` fixes that. Minor thing but why not?