### PR TITLE
Use dynamic site title from gatsby-config.js

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from 'gatsby-link'
 
-const Header = () => (
+const Header = ({ siteTitle }) => (
   <div
     style={{
       background: 'rebeccapurple',
@@ -23,7 +23,7 @@ const Header = () => (
             textDecoration: 'none',
           }}
         >
-          Gatsby
+          {siteTitle}
         </Link>
       </h1>
     </div>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,16 +5,18 @@ import Helmet from 'react-helmet'
 import Header from '../components/Header'
 import './index.css'
 
-const TemplateWrapper = ({ children }) => (
+const TemplateWrapper = ({ children, data }) => (
   <div>
     <Helmet
-      title="Gatsby Default Starter"
+      title={data.site.siteMetadata.title}
       meta={[
         { name: 'description', content: 'Sample' },
         { name: 'keywords', content: 'sample, something' },
       ]}
     />
-    <Header />
+    <Header
+      siteTitle={data.site.siteMetadata.title}
+    />
     <div
       style={{
         margin: '0 auto',
@@ -33,3 +35,13 @@ TemplateWrapper.propTypes = {
 }
 
 export default TemplateWrapper
+
+export const query = graphql`
+  query SiteTitleQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
The site titles are currently hardcoded by default, which I think isn't a good practice for people looking to start with Gatsby.

I've taken the title value from `gatsby-config.js` and retrieved it using GraphQL, before passing it along to the header component. I'm thinking that this example would help those who are unfamiliar with the React ecosystem get started with templating.