### PR TITLE
Added Repository Field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,4 +22,8 @@
   "devDependencies": {
     "prettier": "^1.12.0"
   }
+  "repository" :
+  { "type" : "git"
+  , "url" : "https://github.com/gatsbyjs/gatsby-starter-default"
+  }
 }


### PR DESCRIPTION
As per the docs here https://docs.npmjs.com/files/package.json#repository

> This is helpful for people who want to contribute. If the git repo is on GitHub, then the npm docs command will be able to find you