### PR TITLE
corrected missing div tag in layout component

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -18,7 +18,7 @@ const Layout = ({ children, data }) => (
       }
     `}
     render={data => (
-      <>
+      <div>
         <Helmet
           title={data.site.siteMetadata.title}
           meta={[
@@ -37,7 +37,7 @@ const Layout = ({ children, data }) => (
         >
           {children}
         </div>
-      </>
+      </div>
     )}
   />
 )


### PR DESCRIPTION
The root html tag for the Layout.js component was <> and the closing tag  was </>. Changed to be opening and closing div tags.