### PR TITLE
Format all .js files with Prettier

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,4 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
- // You can delete this file if you're not using it
+// You can delete this file if you're not using it

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,4 +4,4 @@
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
 
- // You can delete this file if you're not using it
+// You can delete this file if you're not using it

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,4 +4,4 @@
  * See: https://www.gatsbyjs.org/docs/ssr-apis/
  */
 
- // You can delete this file if you're not using it
+// You can delete this file if you're not using it

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write 'src/**/*.js'",
+    "format": "prettier --write '**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
-import { StaticQuery, graphql } from "gatsby"
+import { StaticQuery, graphql } from 'gatsby'
 
 import Header from './header'
 import './layout.css'


### PR DESCRIPTION
I notice when bootstrapping a new site with this starter like so:

```
gatsby new gatsby-pages https://github.com/gatsbyjs/gatsby-starter-default\#v2
```

Running `yarn format` in the bootstrapped codebase results in changes to `src/components/layout.js`. This PR formats that file, as well as updating the Prettier glob to `**/*.js` to format all `.js` files. Thoughts on this update?