### PR TITLE
Replace unneeded template literal with normal string

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: [
     'gatsby-plugin-react-helmet',
     {
-      resolve: `gatsby-plugin-manifest`,
+      resolve: 'gatsby-plugin-manifest',
       options: {
         name: 'gatsby-starter-default',
         short_name: 'starter',


### PR DESCRIPTION
Replace unneeded template literal with normal string.