### PR TITLE
fix: make service worker/pwa opt-in and comment gatsby-plugin-offline

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality
-    // To learn more, visit: <ADD_SHORT_LINK>
+    // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',
   ],
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,6 +25,8 @@ module.exports = {
         icon: 'src/images/gatsby-icon.png', // This path is relative to the root of the site.
       },
     },
-    'gatsby-plugin-offline',
+    // this (optional) plugin enables Progressive Web App + Offline functionality
+    // To learn more, visit: <ADD_SHORT_LINK>
+    // 'gatsby-plugin-offline',
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,16 +2919,26 @@
           }
         },
         "htmlparser2": {
-          "version": "3.9.2",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
           "requires": {
             "domelementtype": "^1.3.0",
             "domhandler": "^2.3.0",
             "domutils": "^1.5.1",
             "entities": "^1.1.1",
             "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "readable-stream": "^3.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -6672,14 +6682,14 @@
       }
     },
     "gatsby-plugin-offline": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.5.tgz",
-      "integrity": "sha512-sxdhaylmVlgdW7Vi2DmoKx12/OvpbzxLtn9JfM1MnhG4AGVhXPtbVAfPhx4oaai966A6ze3Bh7XM4DaPEY6WUA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.0.11.tgz",
+      "integrity": "sha512-A2CWtVvH9A+wNIrX8shnYYyskbiX+wdWGbYXytqTRPAFDnbow21qfBWYzXG2phpgwKYb3d2ooXI2pu00ooD/ow==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "cheerio": "^1.0.0-rc.2",
         "lodash": "^4.17.10",
-        "workbox-build": "^3.4.1"
+        "workbox-build": "^3.6.3"
       }
     },
     "gatsby-plugin-page-creator": {
@@ -7133,9 +7143,9 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-own-enumerable-property-symbols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
     },
     "get-port": {
       "version": "3.2.0",
@@ -14091,11 +14101,11 @@
       }
     },
     "stringify-object": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
+        "get-own-enumerable-property-symbols": "^3.0.0",
         "is-obj": "^1.0.1",
         "is-regexp": "^1.0.0"
       }
@@ -15916,25 +15926,25 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "workbox-background-sync": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.5.0.tgz",
-      "integrity": "sha512-cioa4pQswVZqoBqVe/h75gZTzoPQHSjDDMjN4QOIyKJgx+oan3EhoOebY1X9/7XBHpkYdDNC7J7F4CZzrnu2dg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
+      "integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-broadcast-cache-update": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.5.0.tgz",
-      "integrity": "sha512-o1aCtORdKqICjrWVvDg84C4v3yV6gW4VS0axmqMceQJACS0f8idX+AaDd23ZqIEGltpcBe0yOXuc2FLUlNk4gg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
+      "integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-build": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.5.0.tgz",
-      "integrity": "sha512-tORa8YW18IIjm3/4sK8mIBjQkgYv/HS95VC5SEaRTxbcsFDc89oaWtzZiFQ9IgDO1R5v4qfuLQnNZg/lOV6RGQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
+      "integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "common-tags": "^1.4.0",
@@ -15945,19 +15955,19 @@
         "pretty-bytes": "^4.0.2",
         "stringify-object": "^3.2.2",
         "strip-comments": "^1.0.2",
-        "workbox-background-sync": "^3.5.0",
-        "workbox-broadcast-cache-update": "^3.5.0",
-        "workbox-cache-expiration": "^3.5.0",
-        "workbox-cacheable-response": "^3.5.0",
-        "workbox-core": "^3.5.0",
-        "workbox-google-analytics": "^3.5.0",
-        "workbox-navigation-preload": "^3.5.0",
-        "workbox-precaching": "^3.5.0",
-        "workbox-range-requests": "^3.5.0",
-        "workbox-routing": "^3.5.0",
-        "workbox-strategies": "^3.5.0",
-        "workbox-streams": "^3.5.0",
-        "workbox-sw": "^3.5.0"
+        "workbox-background-sync": "^3.6.3",
+        "workbox-broadcast-cache-update": "^3.6.3",
+        "workbox-cache-expiration": "^3.6.3",
+        "workbox-cacheable-response": "^3.6.3",
+        "workbox-core": "^3.6.3",
+        "workbox-google-analytics": "^3.6.3",
+        "workbox-navigation-preload": "^3.6.3",
+        "workbox-precaching": "^3.6.3",
+        "workbox-range-requests": "^3.6.3",
+        "workbox-routing": "^3.6.3",
+        "workbox-strategies": "^3.6.3",
+        "workbox-streams": "^3.6.3",
+        "workbox-sw": "^3.6.3"
       },
       "dependencies": {
         "fs-extra": {
@@ -15983,89 +15993,89 @@
       }
     },
     "workbox-cache-expiration": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.5.0.tgz",
-      "integrity": "sha512-xorlgqgeGsQcZBjUuZ2LVongDZi9MeSOcMTFGGBZiXVKAgRJ7iG34rP3uSdMGKXc9hMF+5g/p0LtxDwenr3tYQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
+      "integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-cacheable-response": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.5.0.tgz",
-      "integrity": "sha512-/R833mjllyV5hveG0w9JmW7mr5/jKWqk6Z9qZbWHoZGxoZfi9SZWqyf0ehJocQlBpOHWV1ynDCeUmkR8AABv8A==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
+      "integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.5.0.tgz",
-      "integrity": "sha512-wZD4iM+Od3ssJLV1JCs7Dl2CswfTAaIhOBlV9WEASqYF9wKUHvJCnF0Cf6vVRaRuV2kaWXH7VB2Yh82eLkjyhQ=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.6.3.tgz",
+      "integrity": "sha512-cx9cx0nscPkIWs8Pt98HGrS9/aORuUcSkWjG25GqNWdvD/pSe7/5Oh3BKs0fC+rUshCiyLbxW54q0hA+GqZeSQ=="
     },
     "workbox-google-analytics": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.5.0.tgz",
-      "integrity": "sha512-eUOgTZkxYegpY16RUGt/J0cP0Zo8VIMyoUJh+StyNp3axpHEULpJPnB+xXH2aAQ1RMI/YVDM5u0az24kjYTfzQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
+      "integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
       "requires": {
-        "workbox-background-sync": "^3.5.0",
-        "workbox-core": "^3.5.0",
-        "workbox-routing": "^3.5.0",
-        "workbox-strategies": "^3.5.0"
+        "workbox-background-sync": "^3.6.3",
+        "workbox-core": "^3.6.3",
+        "workbox-routing": "^3.6.3",
+        "workbox-strategies": "^3.6.3"
       }
     },
     "workbox-navigation-preload": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.5.0.tgz",
-      "integrity": "sha512-5jyd91B9niH7bkNjdwlwK8dgul2tdwtZc5i6UtECZPqakrnfBwm1+3wuaehs2SFxhD5xaYSL7w3B4SMzsP/Tqg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
+      "integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-precaching": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.5.0.tgz",
-      "integrity": "sha512-6fLq14nZtWs3u7C+lzmRUuthJTQc+L4p20tDoW6EtizfiAr8MsY3nYsuuxf2cu4aDU0N7bAe8J7ajnN/cBSF4Q==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
+      "integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-range-requests": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.5.0.tgz",
-      "integrity": "sha512-kYvMTrzMJ4KMwDC1UUgzxU43KmFBnUrB0dVVl3Hro5sPqAOtu2d1xbotypXSgOKKOV41C+SSZQ3X0Hzt5z4B+A==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
+      "integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-routing": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.5.0.tgz",
-      "integrity": "sha512-L5oSFdyBVhGfZ+4c0hA/z7wmtODmjzlXImYSf17/SFOpk4MhDUNSnDl13P2IfhDrUqB+IHPlqTFYKuWU0AhqZQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
+      "integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-strategies": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.5.0.tgz",
-      "integrity": "sha512-3JS96V0jZTNjhOp9tMJwqd0h60K/Sf/LhUUNj8HNT+8Qx61tsP1Ya/1iBFPpeBpJ9qpbnGGeTrXNcOGscn6PNg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
+      "integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-streams": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.5.0.tgz",
-      "integrity": "sha512-AbQASO9hR7O9pFd7zXThLb1T1pPu2ePfMb+hlo+NPcEdiYwUyDTMUHh93umnyE2/9uMT48GNah5ljaA0nGIFqw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
+      "integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
       "requires": {
-        "workbox-core": "^3.5.0"
+        "workbox-core": "^3.6.3"
       }
     },
     "workbox-sw": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.5.0.tgz",
-      "integrity": "sha512-ejFm0EF2yuWAY9qJ4BNRrw3TNheqMGqGiLjZkz3WoWDTR8JAr/1WkfXh+uovG1b7J2UXeMURt3Yng419GK6ttw=="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.6.3.tgz",
+      "integrity": "sha512-IQOUi+RLhvYCiv80RP23KBW/NTtIvzvjex28B8NW1jOm+iV4VIu3VXKXTA6er5/wjjuhmtB28qEAUqADLAyOSg=="
     },
     "worker-farm": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gatsby": "^2.0.19",
     "gatsby-image": "^2.0.15",
     "gatsby-plugin-manifest": "^2.0.5",
-    "gatsby-plugin-offline": "^2.0.5",
+    "gatsby-plugin-offline": "^2.0.11",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.7",
     "gatsby-source-filesystem": "^2.0.4",


### PR DESCRIPTION
Similarly to facebook/create-react-app, I think it makes sense to make the offline/PWA functionality opt-in, rather than enabled by default.

This PR does the following:

- Adds a comment with general explanation re: offline/pwa functionality
- Links to further documentation re: adding offline/pwa support
- Comments gatsby-plugin-offline

It does _not_ remove `gatsby-plugin-offline` from package.json, so it's a simple removal of the comment to get offline support.