### PR TITLE
Use full resolution image

### DIFF
--- a/src/components/image.js
+++ b/src/components/image.js
@@ -19,7 +19,7 @@ const Image = () => (
       query {
         placeholderImage: file(relativePath: { eq: "gatsby-astronaut.png" }) {
           childImageSharp {
-            fluid(maxWidth: 300) {
+            fluid(maxWidth: 600) {
               ...GatsbyImageSharpFluid
             }
           }


### PR DESCRIPTION
I'm trying to better wrap my head around [`gatsby-image`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image), and how it works with high-resolution images.

This particular image source is 800x800. According to [this issue](https://github.com/gatsbyjs/gatsby/issues/2849), sizing queries should be the largest size at 2x resolution. According to that, because this image resides in a `div` with `width` set to `300`, we want to generate a 600x600px version so that it's full resolution.