### PR TITLE
don't export query in SEO component

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -83,7 +83,7 @@ SEO.propTypes = {
 
 export default SEO
 
-export const detailsQuery = graphql`
+const detailsQuery = graphql`
   query DefaultSEOQuery {
     site {
       siteMetadata {


### PR DESCRIPTION
It seems we fail silently in production builds when we export query like that when use with StaticQuery - will need to dig a bit in our babel query extraction, but for now let's fix the default starter