### PR TITLE
Updating Gatsby version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "gatsby": "^2.0.53",
+    "gatsby": "^2.0.75",
     "gatsby-image": "^2.0.20",
     "gatsby-plugin-manifest": "^2.0.9",
     "gatsby-plugin-offline": "^2.0.16",


### PR DESCRIPTION
Resolves an issue with a missing alias in query-queue.js breaking the build for Node < v10.0.0 (see https://github.com/gatsbyjs/gatsby/pull/10613)