### PR TITLE
Refactor footer date to be dynamic

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -29,7 +29,7 @@ const Layout = ({ children }) => (
         >
           {children}
           <footer>
-            © 2018, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
+            © {new Date().getFullYear()}, Built with <a href="https://www.gatsbyjs.org">Gatsby</a>
           </footer>
         </div>
       </>


### PR DESCRIPTION
This will make sure that it will always display the current year as copyright in the footer.