### PR TITLE
Update URL for Gatsby unit testing docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://www.gatsbyjs.org/docs/unit-testing/\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It looks like the unit testing documentation for Gatsby lives at https://www.gatsbyjs.org/docs/unit-testing/.

The old URL to the unit test docs in the `test` script in `package.json` doesn't consistently redirect to https://www.gatsbyjs.org/docs/unit-testing, so I replaced the old testing docs URL with the new one to avoid failed redirects.