### PR TITLE
Exchange Zeit Mentions with Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-default)
 
-[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/gatsbyjs/gatsby-starter-default)
+[![Deploy with Vercel Now](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/gatsbyjs/gatsby-starter-default)
 
 <!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
Changed the README to update mentions of Zeit to Vercel and change the domain name as [Zeit has rebranded to Vercel](https://vercel.com/blog/zeit-is-now-vercel).