### PR TITLE
Gatsby-CLI step in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,29 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
 ## 🚀 Quick start
 
-1.  **Create a Gatsby site.**
+1.  **Install gatsby-cli globally**
+
+     The <a href="https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/README.md">Gatsby CLI</a> is available via npm and is installed globally by using npm.
+    
+     ```shell
+    # install gatsby-cli globally 
+    npm install -g gatsby-cli
+    ```
+      ```shell
+    # Verify its installed by running  
+    gatsby -v
+    ```
+    
+2.  **Create a Gatsby site**  
 
     Use the Gatsby CLI to create a new site, specifying the default starter.
-
+    
     ```shell
     # create a new Gatsby site using the default starter
     gatsby new my-default-starter https://github.com/gatsbyjs/gatsby-starter-default
     ```
 
-1.  **Start developing.**
+3.  **Start developing.**
 
     Navigate into your new site’s directory and start it up.
 
@@ -32,7 +45,7 @@ _Have another more specific idea? You may want to check out our vibrant collecti
     gatsby develop
     ```
 
-1.  **Open the source code and start editing!**
+4.  **Open the source code and start editing!**
 
     Your site is now running at `http://localhost:8000`!
 


### PR DESCRIPTION
Added a Gatsby-cli installation step, for new users landing directly on the starter page.