### PR TITLE
set buildtime in layout.js

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -16,6 +16,7 @@ const Layout = ({ children }) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
+        buildTime(formatString: "YYYY")
         siteMetadata {
           title
         }
@@ -39,7 +40,7 @@ const Layout = ({ children }) => {
             marginTop: `2rem`,
           }}
         >
-          © {new Date().getFullYear()}, Built with
+          © {data.site.buildTime}, Built with
           {` `}
           <a href="https://www.gatsbyjs.com">Gatsby</a>
         </footer>


### PR DESCRIPTION
Why did we use new Date()? It's mutable and unrelated to build time