### PR TITLE
Remove dot before tsconfig on /using-typescript page

### DIFF
--- a/src/pages/using-typescript.tsx
+++ b/src/pages/using-typescript.tsx
@@ -22,7 +22,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
     </p>
     <p>
       For type checking you'll want to install <em>typescript</em> via npm and
-      run <em>tsc --init</em> to create a <em>.tsconfig</em> file.
+      run <em>tsc --init</em> to create a <em>tsconfig</em> file.
     </p>
     <p>
       You're currently on the page "{path}" which was built on{" "}


### PR DESCRIPTION
Small typo fix. TypeScript `tsconfig.json` file does not have a dot infront of it.