### PR TITLE
removed the duplidate utm content from the footer links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,19 +50,19 @@ const moreLinks = [
   { text: "Join us on Discord", url: "https://gatsby.dev/discord" },
   {
     text: "Documentation",
-    url: "https://gatsbyjs.com/docs/?utm_source=starter&utm_medium=start-page&utm_campaign=default-starter",
+    url: "https://gatsbyjs.com/docs/",
   },
   {
     text: "Starters",
-    url: "https://gatsbyjs.com/starters/?utm_source=starter&utm_medium=start-page&utm_campaign=default-starter",
+    url: "https://gatsbyjs.com/starters/",
   },
   {
     text: "Showcase",
-    url: "https://gatsbyjs.com/showcase/?utm_source=starter&utm_medium=start-page&utm_campaign=default-starter",
+    url: "https://gatsbyjs.com/showcase/",
   },
   {
     text: "Contributing",
-    url: "https://www.gatsbyjs.com/contributing/?utm_source=starter&utm_medium=start-page&utm_campaign=default-starter",
+    url: "https://www.gatsbyjs.com/contributing/",
   },
   { text: "Issues", url: "https://github.com/gatsbyjs/gatsby/issues" },
 ]


### PR DESCRIPTION
The utm's were previously both in each `moreLinks` entry _and_ appended via the `map` call, resulting in duplicate utm parameters for those links.

This changes fixes it.